### PR TITLE
Fix class incompatibility with latest DiscordSRV version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <dependency>
             <groupId>com.discordsrv</groupId>
             <artifactId>discordsrv</artifactId>
-            <version>1.26.1-SNAPSHOT</version>
+            <version>1.27.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Class changed to interface in https://github.com/DiscordSRV/DiscordSRV/commit/d581ed1bdd2eaf23a43f6f29c58a0c75cb2a05d7, Java complains about the type being an interface now. No code changes necessary besides updating version.

```
[07:57:29] [Craft Scheduler Thread - 6/WARN]: java.lang.IncompatibleClassChangeError: Found interface github.scarsz.discordsrv.objects.managers.AccountLinkManager, but class was expected
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at com.loohp.interactivechatdiscordsrvaddon.listeners.OutboundToDiscordEvents.processGameMessage(OutboundToDiscordEvents.java:586)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at com.loohp.interactivechatdiscordsrvaddon.listeners.OutboundToDiscordEvents.handleGameToDiscord(OutboundToDiscordEvents.java:206)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at com.loohp.interactivechatdiscordsrvaddon.listeners.OutboundToDiscordEvents.onGameToDiscordHighest(OutboundToDiscordEvents.java:183)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at github.scarsz.discordsrv.api.ApiManager.invokeMethod(ApiManager.java:344)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at github.scarsz.discordsrv.api.ApiManager.callEvent(ApiManager.java:149)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at github.scarsz.discordsrv.DiscordSRV.processChatMessage(DiscordSRV.java:1679)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at github.scarsz.discordsrv.DiscordSRV.processChatMessage(DiscordSRV.java:1615)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at github.scarsz.discordsrv.listeners.PlayerChatListener.lambda$onAsyncPlayerChat$0(PlayerChatListener.java:43)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftTask.run(CraftTask.java:82)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at org.bukkit.craftbukkit.v1_20_R3.scheduler.CraftAsyncTask.run(CraftAsyncTask.java:54)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[07:57:29] [Craft Scheduler Thread - 6/WARN]: at java.base/java.lang.Thread.run(Thread.java:840)
```