### PR TITLE
Adds a config option to turn off mentions on Discord.

### DIFF
--- a/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/InteractiveChatDiscordSrvAddon.java
+++ b/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/InteractiveChatDiscordSrvAddon.java
@@ -186,6 +186,7 @@ public class InteractiveChatDiscordSrvAddon extends JavaPlugin implements Listen
     public boolean imageWhitelistEnabled = false;
     public List<String> whitelistedImageUrls = new ArrayList<>();
     public boolean translateMentions = true;
+    public boolean sendDiscordMention = true;
     public String mentionHighlight = "";
     public boolean deathMessageItem = true;
     public boolean deathMessageTranslated = true;
@@ -545,6 +546,7 @@ public class InteractiveChatDiscordSrvAddon extends JavaPlugin implements Listen
         advancementDescription = config.getConfiguration().getBoolean("Advancements.ShowDescription");
 
         translateMentions = config.getConfiguration().getBoolean("DiscordMention.TranslateMentions");
+        sendDiscordMention = config.getConfiguration().getBoolean("DiscordMention.DiscordMentionSend");
         mentionHighlight = ChatColorUtils.translateAlternateColorCodes('&', config.getConfiguration().getString("DiscordMention.MentionHighlight"));
 
         playbackBarEnabled = config.getConfiguration().getBoolean("DiscordAttachments.PlaybackBar.Enabled");

--- a/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/listeners/OutboundToDiscordEvents.java
+++ b/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/listeners/OutboundToDiscordEvents.java
@@ -564,7 +564,7 @@ public class OutboundToDiscordEvents implements Listener {
         }
 
         DiscordSRV srv = InteractiveChatDiscordSrvAddon.discordsrv;
-        if (InteractiveChatDiscordSrvAddon.plugin.translateMentions) {
+        if (InteractiveChatDiscordSrvAddon.plugin.sendDiscordMention) {
             Debug.debug("onGameToDiscord processing mentions");
             boolean hasMentionPermission = PlayerUtils.hasPermission(icSender.getUniqueId(), "interactivechat.mention.player", true, 200);
             if (hasMentionPermission) {

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -282,6 +282,8 @@ DiscordMention:
   #Use {TextChannel} for the pinged channel name
   #Use {Guild} for the pinged guild name
   DiscordMentionSubtitle: "&9{DiscordUser} &fmentioned you in &9{TextChannel}!"
+  #Send mention on discord, If the option is true and someone pings you in-game, It will ping you on Discord.
+  DiscordMentionSend: true
   DiscordMentionActionbar: ""
 
   #Highlight the mentioned playername for the player mentioned


### PR DESCRIPTION
Adds a toggle to disable being mentioned on Discord when mentioned in-game if account is linked, It replaces `translateMentions` in `OutboundToDiscordEvents` however default is true so it should function the same out of the box.