### PR TITLE
Add CraftEngine item rendering support

### DIFF
--- a/V1_10/pom.xml
+++ b/V1_10/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_10</artifactId>

--- a/V1_11/pom.xml
+++ b/V1_11/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_11</artifactId>

--- a/V1_12/pom.xml
+++ b/V1_12/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_12</artifactId>

--- a/V1_13/pom.xml
+++ b/V1_13/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_13</artifactId>

--- a/V1_13_1/pom.xml
+++ b/V1_13_1/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_13_1</artifactId>

--- a/V1_14/pom.xml
+++ b/V1_14/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_14</artifactId>

--- a/V1_15/pom.xml
+++ b/V1_15/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_15</artifactId>

--- a/V1_16/pom.xml
+++ b/V1_16/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_16</artifactId>

--- a/V1_16_2/pom.xml
+++ b/V1_16_2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_16_2</artifactId>

--- a/V1_16_4/pom.xml
+++ b/V1_16_4/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_16_4</artifactId>

--- a/V1_17/pom.xml
+++ b/V1_17/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_17</artifactId>

--- a/V1_18/pom.xml
+++ b/V1_18/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_18</artifactId>

--- a/V1_18_2/pom.xml
+++ b/V1_18_2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_18_2</artifactId>

--- a/V1_19/pom.xml
+++ b/V1_19/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_19</artifactId>

--- a/V1_19_3/pom.xml
+++ b/V1_19_3/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_19_3</artifactId>

--- a/V1_19_4/pom.xml
+++ b/V1_19_4/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_19_4</artifactId>

--- a/V1_20/pom.xml
+++ b/V1_20/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_20</artifactId>

--- a/V1_20_2/pom.xml
+++ b/V1_20_2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_20_2</artifactId>

--- a/V1_20_3/pom.xml
+++ b/V1_20_3/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_20_3</artifactId>

--- a/V1_20_5/pom.xml
+++ b/V1_20_5/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_20_5</artifactId>

--- a/V1_20_6/pom.xml
+++ b/V1_20_6/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_20_6</artifactId>

--- a/V1_21/pom.xml
+++ b/V1_21/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21</artifactId>

--- a/V1_21_1/pom.xml
+++ b/V1_21_1/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_1</artifactId>

--- a/V1_21_10/pom.xml
+++ b/V1_21_10/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_10</artifactId>

--- a/V1_21_11/pom.xml
+++ b/V1_21_11/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_11</artifactId>

--- a/V1_21_2/pom.xml
+++ b/V1_21_2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_2</artifactId>

--- a/V1_21_3/pom.xml
+++ b/V1_21_3/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_3</artifactId>

--- a/V1_21_4/pom.xml
+++ b/V1_21_4/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_4</artifactId>

--- a/V1_21_5/pom.xml
+++ b/V1_21_5/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_5</artifactId>

--- a/V1_21_6/pom.xml
+++ b/V1_21_6/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_6</artifactId>

--- a/V1_21_7/pom.xml
+++ b/V1_21_7/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_7</artifactId>

--- a/V1_21_8/pom.xml
+++ b/V1_21_8/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_8</artifactId>

--- a/V1_21_9/pom.xml
+++ b/V1_21_9/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_21_9</artifactId>

--- a/V1_8/pom.xml
+++ b/V1_8/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_8</artifactId>

--- a/V1_8_3/pom.xml
+++ b/V1_8_3/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_8_3</artifactId>

--- a/V1_8_4/pom.xml
+++ b/V1_8_4/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_8_4</artifactId>

--- a/V1_9/pom.xml
+++ b/V1_9/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_9</artifactId>

--- a/V1_9_4/pom.xml
+++ b/V1_9_4/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V1_9_4</artifactId>

--- a/V26_1/pom.xml
+++ b/V26_1/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V26_1</artifactId>

--- a/V26_1_1/pom.xml
+++ b/V26_1_1/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V26_1_1</artifactId>

--- a/V26_1_2/pom.xml
+++ b/V26_1_2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-V26_1_2</artifactId>

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.loohp</groupId>
         <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-        <version>2026.1.0.0</version>
+        <version>2026.1.0.2</version>
     </parent>
 
     <artifactId>InteractiveChatDiscordSrvAddon-Abstraction</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.loohp</groupId>
     <artifactId>InteractiveChatDiscordSrvAddon</artifactId>
     <name>InteractiveChatDiscordSrvAddon</name>
-    <version>2026.1.0.0</version>
+    <version>2026.1.0.2</version>
 
     <description>Have InteractiveChat Placeholders translated on DiscordSRV discord messages.</description>
     <url>https://github.com/LOOHP/InteractiveChat-DiscordSRV-Addon</url>
@@ -303,6 +303,10 @@
         <repository>
             <id>loohp-repo</id>
             <url>https://repo.loohpjames.com/repository</url>
+        </repository>
+        <repository>
+            <id>momirealms-releases</id>
+            <url>https://repo.momirealms.net/releases/</url>
         </repository>
     </repositories>
 
@@ -672,6 +676,18 @@
             <artifactId>InteractiveChatDiscordSrvAddon-V26_1_2</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.momirealms</groupId>
+            <artifactId>craft-engine-core</artifactId>
+            <version>0.0.67</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.momirealms</groupId>
+            <artifactId>craft-engine-bukkit</artifactId>
+            <version>0.0.67</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/InteractiveChatDiscordSrvAddon.java
+++ b/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/InteractiveChatDiscordSrvAddon.java
@@ -130,6 +130,7 @@ public class InteractiveChatDiscordSrvAddon extends JavaPlugin implements Listen
 
     public static boolean itemsAdderHook = false;
     public static boolean imageFrameHook = false;
+    public static boolean craftEngineHook = false;
 
     public static boolean isReady = false;
 
@@ -368,6 +369,11 @@ public class InteractiveChatDiscordSrvAddon extends JavaPlugin implements Listen
             getServer().getConsoleSender().sendMessage(ChatColor.AQUA + "[ICDiscordSrvAddon] InteractiveChat DiscordSRV Addon has hooked into ImageFrame!");
             Bukkit.getPluginManager().registerEvents(new ImageFrameEvents(), this);
             imageFrameHook = true;
+        }
+
+        if (Bukkit.getPluginManager().isPluginEnabled("CraftEngine")) {
+            Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "[ICDiscordSrvAddon] Hooked into CraftEngine");
+            craftEngineHook = true;
         }
 
         if (!compatible()) {

--- a/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/InteractiveChatDiscordSrvAddon.java
+++ b/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/InteractiveChatDiscordSrvAddon.java
@@ -42,6 +42,7 @@ import com.loohp.interactivechatdiscordsrvaddon.api.events.ResourceManagerInitia
 import com.loohp.interactivechatdiscordsrvaddon.debug.Debug;
 import com.loohp.interactivechatdiscordsrvaddon.graphics.ImageGeneration;
 import com.loohp.interactivechatdiscordsrvaddon.graphics.ImageUtils;
+import com.loohp.interactivechatdiscordsrvaddon.hooks.craftengine.CraftEngineHook;
 import com.loohp.interactivechatdiscordsrvaddon.hooks.imageframe.ImageFrameEvents;
 import com.loohp.interactivechatdiscordsrvaddon.listeners.DiscordCommandEvents;
 import com.loohp.interactivechatdiscordsrvaddon.listeners.DiscordInteractionEvents;
@@ -780,6 +781,13 @@ public class InteractiveChatDiscordSrvAddon extends JavaPlugin implements Listen
                     String resourceName = serverResourcePack.getName();
                     Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "[ICDiscordSrvAddon] Loading \"" + resourceName + "\" resources...");
                     sources.add(ResourcePackSource.ofCustom(resourceName, serverResourcePack, ResourcePackType.SERVER));
+                }
+                if (craftEngineHook) {
+                    File cePackFile = CraftEngineHook.getGeneratedResourcePackFile();
+                    if (cePackFile != null) {
+                        Bukkit.getConsoleSender().sendMessage(ChatColor.AQUA + "[ICDiscordSrvAddon] Loading \"CraftEngine\" resources...");
+                        sources.add(ResourcePackSource.ofCustom("CraftEngine", cePackFile, ResourcePackType.SERVER));
+                    }
                 }
                 resourceManager.loadResources(sources, (source, info) -> {
                     String resourceName = source.getName();

--- a/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/graphics/ImageGeneration.java
+++ b/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/graphics/ImageGeneration.java
@@ -109,6 +109,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.trim.ArmorTrim;
 import org.bukkit.map.MapCursor;
 import org.bukkit.map.MapPalette;
+import com.loohp.interactivechatdiscordsrvaddon.hooks.craftengine.CraftEngineHook;
 
 import java.awt.Color;
 import java.awt.GradientPaint;
@@ -817,6 +818,9 @@ public class ImageGeneration {
     }
 
     private static BufferedImage getSingleRawItemImage(ItemStack item, OfflineICPlayer player, int size) throws IOException {
+        if (InteractiveChatDiscordSrvAddon.craftEngineHook) {
+            item = CraftEngineHook.toClientSideItemStack(item, player);
+        }
         return getRawItemImage(item, player, size, ModelRenderer.SINGLE_RENDER).get(0);
     }
 

--- a/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/hooks/craftengine/CraftEngineHook.java
+++ b/common/src/main/java/com/loohp/interactivechatdiscordsrvaddon/hooks/craftengine/CraftEngineHook.java
@@ -1,0 +1,112 @@
+package com.loohp.interactivechatdiscordsrvaddon.hooks.craftengine;
+
+import com.loohp.interactivechat.objectholders.OfflineICPlayer;
+import net.momirealms.craftengine.bukkit.api.CraftEngineItems;
+import net.momirealms.craftengine.bukkit.item.BukkitItemManager;
+import net.momirealms.craftengine.bukkit.plugin.BukkitCraftEngine;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public final class CraftEngineHook {
+
+    private CraftEngineHook() {
+    }
+
+    public static boolean isAvailable() {
+        try {
+            return Bukkit.getPluginManager().isPluginEnabled("CraftEngine")
+                    && BukkitCraftEngine.instance() != null
+                    && BukkitItemManager.instance() != null;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    public static boolean isCustomItem(ItemStack itemStack) {
+        if (!isAvailable() || isEmpty(itemStack)) {
+            return false;
+        }
+
+        try {
+            return CraftEngineItems.isCustomItem(itemStack);
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    public static String getCustomItemId(ItemStack itemStack) {
+        if (!isAvailable() || isEmpty(itemStack)) {
+            return null;
+        }
+
+        try {
+            net.momirealms.craftengine.core.util.Key key = CraftEngineItems.getCustomItemId(itemStack);
+            return key == null ? null : key.toString();
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+
+    public static ItemStack toClientSideItemStack(ItemStack itemStack, OfflineICPlayer icPlayer) {
+        if (!isAvailable() || isEmpty(itemStack)) {
+            return itemStack;
+        }
+
+        ItemStack clone = itemStack.clone();
+
+        try {
+            net.momirealms.craftengine.core.entity.player.Player craftEnginePlayer = adaptPlayer(icPlayer);
+
+            Optional<ItemStack> converted = BukkitItemManager.instance().s2c(clone, craftEnginePlayer);
+            return converted.orElse(clone);
+        } catch (Throwable ignored) {
+            return clone;
+        }
+    }
+
+
+    public static File getGeneratedResourcePackFile() {
+        if (!isAvailable()) {
+            return null;
+        }
+
+        try {
+            Path path = BukkitCraftEngine.instance().packManager().resourcePackPath();
+            if (path != null && Files.exists(path) && Files.isRegularFile(path)) {
+                return path.toFile();
+            }
+        } catch (Throwable ignored) {
+        }
+
+        return null;
+    }
+
+    private static net.momirealms.craftengine.core.entity.player.Player adaptPlayer(OfflineICPlayer icPlayer) {
+        if (icPlayer == null || !icPlayer.isOnline() || icPlayer.getPlayer() == null || !icPlayer.getPlayer().isLocal()) {
+            return null;
+        }
+
+        try {
+            Player bukkitPlayer = icPlayer.getPlayer().getLocalPlayer();
+            if (bukkitPlayer == null) {
+                return null;
+            }
+
+            return BukkitCraftEngine.instance().adapt(bukkitPlayer);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private static boolean isEmpty(ItemStack itemStack) {
+        return itemStack == null || itemStack.getType().equals(Material.AIR) || itemStack.getAmount() <= 0;
+    }
+}

--- a/common/src/main/resources/plugin.yml
+++ b/common/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ api-version: 1.13
 folia-supported: true
 description: DiscordSRV addon to InteractiveChat
 depend: [InteractiveChat, DiscordSRV]
-softdepend: [ItemsAdder, ImageFrame]
+softdepend: [ItemsAdder, ImageFrame, CraftEngine]
 prefix: InteractiveChatDiscordSRVAddon
 
 commands:

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.loohp</groupId>
     <artifactId>InteractiveChatDiscordSrvAddon-Parent</artifactId>
-    <version>2026.1.0.0</version>
+    <version>2026.1.0.2</version>
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
Adds optional CraftEngine support to InteractiveChatDiscordSrvAddon item rendering.

This fixes CraftEngine custom items/blocks not rendering correctly. ICD will still need the resourcepack to render the items properly.